### PR TITLE
Upgrade to 0.18

### DIFF
--- a/Css.elm
+++ b/Css.elm
@@ -217,8 +217,8 @@ sel : Sel id cls -> String
 sel selector =
     case selector of
         Type element -> element
-        Id id -> '#' `cons` (toString id)
-        Class cls -> '.' `cons` (toString cls)
+        Id id -> cons '#' (toString id)
+        Class cls -> cons '.' (toString cls)
         Descendant s1 s2 -> join " " [sel s2, sel s1]
         Child s1 s2 -> join " > " [sel s2, sel s1]
         Sibling s1 s2 -> join " ~ " [sel s2, sel s1]

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "Css"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
I needed your elm-css package upgraded to 0.18, so I did it. I'm using a copy now, but will switch back to using your version as soon as you "elm package bump", create and push the new tag, and "elm package publish".

Thank you for this. It has helped me greatly, and is so much easier to deal with, though I guess a little less "Elmy", than rtfeldman/elm-css.